### PR TITLE
fix: connection reliability fixes (silent failures after widget re-add)

### DIFF
--- a/package/contents/ui/Client.qml
+++ b/package/contents/ui/Client.qml
@@ -47,7 +47,8 @@ BaseObject {
     WebSocket {
         id: ws
         property bool ready: false
-        property int messageCounter: 0
+        // HA rejects id 0 as "Message incorrectly formatted" — ids must start at 1
+        property int messageCounter: 1
         property var subscriptions: new Map()
         property var promises: new Map()
         readonly property bool open: status === WebSocket.Open

--- a/package/contents/ui/ClientFactory.qml
+++ b/package/contents/ui/ClientFactory.qml
@@ -33,7 +33,9 @@ BaseObject {
 
     function _createClient(baseUrl) {
         const client = clientComponent.createObject(null, { baseUrl })
-        secrets.getToken(baseUrl).then(t => client.token = t)
+        secrets.getToken(baseUrl)
+            .then(t => client.token = t)
+            .catch(e => client.errorString = i18n("Failed to read the access token from KDE Wallet") + (e ? `: ${e}` : ''))
         return client
     }
 

--- a/package/contents/ui/ConfigGeneral.qml
+++ b/package/contents/ui/ConfigGeneral.qml
@@ -41,15 +41,16 @@ KCM.SimpleKCM {
             onActiveFocusChanged: !activeFocus && setValue(editText)
             onHoveredChanged: !hovered && setValue(editText)
             onAccepted: setValue(editText)
-            onActivated: {
-                secrets.restore(editText)
-                setValue(editText)
-            }
+            onActivated: setValue(editText)
             Kirigami.FormData.label: i18n("Home Assistant URL")
             Layout.fillWidth: true
 
             function setValue(value) {
-                cfg_url = editText = value ? value.replace(/\s+|\/+\s*$/g,'') : ''
+                const cleaned = value ? value.replace(/\s+|\/+\s*$/g,'') : ''
+                if (cleaned !== cfg_url) {
+                    secrets.restore(cleaned)
+                }
+                cfg_url = editText = cleaned
             }
         }
 
@@ -75,6 +76,9 @@ KCM.SimpleKCM {
     }
     
     function saveConfig() {
-        secrets.set(url.editText, token.text)
+        // an empty field would overwrite the token stored in the wallet
+        if (token.text) {
+            secrets.set(url.editText, token.text)
+        }
     }
 }

--- a/package/contents/ui/ConfigItems.qml
+++ b/package/contents/ui/ConfigItems.qml
@@ -145,9 +145,16 @@ KCM.ScrollViewKCM {
 
     Component.onCompleted: {
         setItems(cfg_items)
-        ha = ClientFactory.getClient(this, plasmoid.configuration.url)
-        ha.readyChanged.connect(fetchData)
+        ha = ClientFactory.getClient(this, plasmoid.configuration.url) ?? null
+        if (ha) {
+            ha.readyChanged.connect(fetchData)
+            fetchData()
+        } else {
+            busy = false
+        }
     }
+
+    Component.onDestruction: ha?.readyChanged.disconnect(fetchData)
 
     function setItems(data) {
         const rawItems = JSON.parse(data) || []

--- a/package/contents/ui/Store.qml
+++ b/package/contents/ui/Store.qml
@@ -17,18 +17,21 @@ BaseObject {
         fetchDataAndSubscribe()
     }
 
+    Component.onDestruction: setClient(null)
+
     function setClient(client) {
         if (_.client) {
             _.unsubscribe()
             _.client.readyChanged.disconnect(fetchDataAndSubscribe)
         }
         _.client = client
+        if (!client) return
         fetchDataAndSubscribe()
-        _.client.readyChanged.connect(fetchDataAndSubscribe)
+        client.readyChanged.connect(fetchDataAndSubscribe)
     }
 
     function fetchDataAndSubscribe() {
-        if (!_.client?.ready) return
+        if (!_?.client?.ready) return
         fetchFieldsInfo()
         _.subscribe()
     }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -11,7 +11,7 @@ PlasmoidItem {
     fullRepresentation: FullRepresentation {}
     Plasmoid.backgroundHints: PlasmaCore.Types.StandardBackground | PlasmaCore.Types.ConfigurableBackground
     Plasmoid.configurationRequired: !ClientFactory.error && !(url && ha?.token && store.items.length)
-    Plasmoid.busy: !ClientFactory.error && !plasmoid.configurationRequired && !store.initialized
+    Plasmoid.busy: !ClientFactory.error && !ha?.errorString && !plasmoid.configurationRequired && !store.initialized
     toolTipMainText: ""
     toolTipSubText: ""
     


### PR DESCRIPTION
Split out of #88 as requested. These are the connection-reliability fixes only.  Nothing here depends on the thermostat work. Each commit is self-contained and addresses one way the widget could end up silently disconnected or stuck loading.

`fix(client): start WebSocket message ids at 1`  - Home Assistant rejects a command with id: 0 as "Message incorrectly formatted" — ids must start at 1. The message counter started at 0, so the first tracked command a client sent could be rejected, its promise never settled, and the widget left waiting for data with no visible error.

`fix: surface KDE Wallet read errors instead of spinning forever` - If the token couldn't be read from KDE Wallet (wallet locked, closed, or unavailable), the client silently never authenticated and the plasmoid showed the busy spinner indefinitely. The failure is now reported through the client's errorString (rendered by the existing error UI in the full representation), and the busy indicator stops once an error is known.

`fix(store): detach client handlers when the store is destroyed` - Store connected readyChanged on the shared cached client but never disconnected it. Since ClientFactory caches one client per URL across plasmoid instances, removing a widget left a dead store's handler attached — a re-added widget could end up with subscriptions routed through the destroyed store and never receive updates. The store now cleans up on Component.onDestruction (and setClient(null) is handled).

`fix(config): don't overwrite the stored token with an empty field` - The token field is intentionally left empty when opening settings, but saving the dialog wrote that empty value to the wallet, wiping the stored token - the widget then failed to authenticate after the next reconnect with no indication why. An empty field now leaves the stored token untouched. The stored token is also restored whenever the URL value actually changes, not only when an autocomplete entry is activated.

`fix(config): handle unavailable client in the items editor` - With no URL configured yet, ClientFactory.getClient returns nothing; the items page now handles that instead of erroring (and stops the busy state), and disconnects its readyChanged handler when the dialog closes.